### PR TITLE
Convert HTML terminal to WordPress FSE theme

### DIFF
--- a/farshid-terminal/archive.php
+++ b/farshid-terminal/archive.php
@@ -1,0 +1,17 @@
+<?php get_header(); ?>
+<main class="container py-5">
+<h1><?php the_archive_title(); ?></h1>
+<?php
+if ( have_posts() ) {
+    while ( have_posts() ) {
+        the_post();
+        echo '<h2><a href="' . get_permalink() . '">' . get_the_title() . '</a></h2>';
+        the_excerpt();
+    }
+    the_posts_pagination();
+} else {
+    echo '<p>No posts found.</p>';
+}
+?>
+</main>
+<?php get_footer(); ?>

--- a/farshid-terminal/assets/css/terminal.css
+++ b/farshid-terminal/assets/css/terminal.css
@@ -1,0 +1,127 @@
+html, body {
+    height: 100%;
+    margin: 0;
+}
+
+body {
+    background-color: #000;
+    color: #0f0;
+    font-family: monospace;
+}
+
+.farshid_terminal_header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0.5rem 1rem;
+    background-color: #111;
+    color: #0f0;
+}
+
+.farshid_logo {
+    font-weight: bold;
+    font-size: 1.2rem;
+}
+
+.farshid_header_controls {
+    display: flex;
+    align-items: center;
+    gap: 0.2rem;
+}
+
+.farshid_search {
+    border: 1px solid #0f0;
+    background: transparent;
+    color: #0f0;
+    padding: 0.3rem 0.6rem;
+    border-radius: 0.25rem;
+}
+
+.farshid_daynight_btn {
+    cursor: pointer;
+    background: none;
+    border: none;
+    color: #0f0;
+    font-size: 1.2rem;
+}
+
+.farshid_terminal_output {
+    flex: 1;
+    overflow-y: auto;
+    white-space: pre-wrap;
+    display: flex;
+    flex-direction: column;
+    padding: 1rem;
+}
+
+.farshid_terminal_block {
+    margin-bottom: 0.3rem;
+}
+
+.farshid_terminal_command {
+    color: cyan;
+}
+
+.farshid_terminal_result {
+    color: #0f0;
+}
+
+.farshid_terminal_input_row {
+    display: flex;
+    align-items: center;
+    padding: 0 1rem 1rem;
+}
+
+.farshid_terminal_prompt {
+    margin-right: 0.5rem;
+}
+
+.farshid_terminal_input {
+    border: none;
+    outline: none;
+    background: transparent;
+    color: #0f0;
+    flex: 1;
+    font-family: monospace;
+}
+
+.farshid_terminal_help {
+    padding: 0 1rem;
+    color: #0f0;
+    margin-top: 0.5rem;
+    font-size: 0.9rem;
+}
+
+footer {
+    background: #111;
+    color: #0f0;
+    text-align: center;
+    padding: 0.5rem;
+    font-size: 0.85rem;
+}
+
+.dark-mode {
+    background-color: #000 !important;
+    color: #0f0 !important;
+}
+
+.light-mode {
+    background-color: #f0f0f0 !important;
+    color: #000 !important;
+}
+
+.light-mode input.farshid_search,
+.light-mode .farshid_terminal_input {
+    color: #000 !important;
+    border-color: #000 !important;
+}
+
+.light-mode footer {
+    background: #ccc !important;
+    color: #000 !important;
+}
+
+.light-mode .farshid_terminal_header {
+    background-color: #ddd !important;
+    color: #000 !important;
+}

--- a/farshid-terminal/assets/js/terminal.js
+++ b/farshid-terminal/assets/js/terminal.js
@@ -1,0 +1,114 @@
+const farshid_output = document.getElementById('farshid_terminal_output');
+const farshid_input = document.getElementById('farshid_terminal_input');
+const farshid_daynight_btn = document.getElementById('farshid_daynight_btn');
+const farshid_search = document.querySelector('.farshid_search');
+let blogPage = 1;
+
+function farshid_addBlock(command, output, isWarning = false) {
+    const block = document.createElement('div');
+    block.className = 'farshid_terminal_block';
+
+    const cmdLine = document.createElement('div');
+    cmdLine.className = 'farshid_terminal_command';
+    cmdLine.textContent = `> ${command}`;
+
+    const resultLine = document.createElement('div');
+    resultLine.className = 'farshid_terminal_result';
+    resultLine.textContent = output;
+    if (isWarning) {
+        resultLine.style.color = 'yellow';
+    }
+
+    block.appendChild(cmdLine);
+    block.appendChild(resultLine);
+
+    farshid_output.appendChild(block);
+    farshid_output.scrollTop = farshid_output.scrollHeight;
+}
+
+function listPages() {
+    fetch('/wp-json/wp/v2/pages?per_page=100')
+        .then(r => r.json())
+        .then(pages => {
+            const names = pages.map(p => p.slug).join('\n');
+            farshid_addBlock('help', `Pages:\n${names}`);
+        });
+}
+
+function listPosts(page) {
+    fetch(`/wp-json/wp/v2/posts?per_page=10&page=${page}`)
+        .then(r => r.json())
+        .then(posts => {
+            const titles = posts.map(p => `${p.id}: ${p.title.rendered}`).join('\n');
+            farshid_addBlock(`help blog ${page}`, `Posts:\n${titles}`);
+        });
+}
+
+function openPage(slug) {
+    fetch(`/wp-json/wp/v2/pages?slug=${slug}`)
+        .then(r => r.json())
+        .then(pages => {
+            if (pages.length) {
+                farshid_addBlock(`open ${slug}`, pages[0].content.rendered.replace(/<[^>]+>/g, ''));
+            } else {
+                farshid_addBlock(`open ${slug}`, 'Page not found', true);
+            }
+        });
+}
+
+function openPost(id) {
+    window.open(`/index.php?p=${id}`, '_blank');
+}
+
+function farshid_handleCommand(cmd) {
+    if (cmd === 'help') {
+        listPages();
+    } else if (cmd.startsWith('help blog')) {
+        const parts = cmd.split(' ');
+        blogPage = parseInt(parts[2]) || 1;
+        listPosts(blogPage);
+    } else if (cmd.startsWith('open ')) {
+        const slug = cmd.substring(5);
+        openPage(slug);
+    } else if (cmd.startsWith('open-post ')) {
+        const id = cmd.substring(10);
+        openPost(id);
+    } else if (cmd === 'clear') {
+        farshid_output.innerHTML = '';
+    } else {
+        farshid_addBlock(cmd, `Command not found: ${cmd}`, true);
+    }
+}
+
+farshid_input.addEventListener('keydown', function (e) {
+    if (e.key === 'Enter') {
+        const cmd = farshid_input.value.trim();
+        if (cmd) {
+            farshid_handleCommand(cmd);
+            farshid_input.value = '';
+        }
+    }
+});
+
+farshid_daynight_btn.addEventListener('click', function () {
+    document.body.classList.toggle('light-mode');
+    if (document.body.classList.contains('light-mode')) {
+        farshid_daynight_btn.innerHTML = '&#9728;';
+    } else {
+        farshid_daynight_btn.innerHTML = '&#9790;';
+    }
+});
+
+farshid_search.addEventListener('keydown', function(e) {
+    if (e.key === 'Enter') {
+        const term = farshid_search.value.trim();
+        if (term) {
+            fetch(`/wp-json/wp/v2/search?search=${encodeURIComponent(term)}`)
+                .then(r => r.json())
+                .then(results => {
+                    const out = results.map(r => r.title).join('\n');
+                    farshid_addBlock('search', out);
+                });
+        }
+    }
+});

--- a/farshid-terminal/footer.php
+++ b/farshid-terminal/footer.php
@@ -1,0 +1,6 @@
+<footer>
+    &copy; <?php echo date('Y'); ?> <?php bloginfo('name'); ?>. All rights reserved.
+</footer>
+<?php wp_footer(); ?>
+</body>
+</html>

--- a/farshid-terminal/functions.php
+++ b/farshid-terminal/functions.php
@@ -1,0 +1,7 @@
+<?php
+function farshid_terminal_scripts() {
+    wp_enqueue_style('bootstrap', 'https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css');
+    wp_enqueue_style('farshid-terminal', get_stylesheet_uri());
+    wp_enqueue_script('farshid-terminal', get_template_directory_uri() . '/assets/js/terminal.js', array(), null, true);
+}
+add_action('wp_enqueue_scripts', 'farshid_terminal_scripts');

--- a/farshid-terminal/header.php
+++ b/farshid-terminal/header.php
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html <?php language_attributes(); ?>>
+<head>
+    <meta charset="<?php bloginfo( 'charset' ); ?>">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <?php wp_head(); ?>
+</head>
+<body <?php body_class(); ?>>
+<header class="farshid_terminal_header">
+    <div class="farshid_logo"><?php bloginfo('name'); ?></div>
+    <div class="farshid_header_controls">
+        <input type="text" class="farshid_search" placeholder="Search...">
+        <button id="farshid_daynight_btn" class="farshid_daynight_btn">&#9790;</button>
+    </div>
+</header>
+<div class="farshid_terminal_help">Type 'help' to see available commands</div>
+<div id="farshid_terminal_output" class="farshid_terminal_output"></div>
+<div class="farshid_terminal_input_row">
+    <div class="farshid_terminal_prompt">&gt;</div>
+    <input id="farshid_terminal_input" class="farshid_terminal_input" type="text" placeholder="Type your command...">
+</div>

--- a/farshid-terminal/index.php
+++ b/farshid-terminal/index.php
@@ -1,0 +1,2 @@
+<?php get_header(); ?>
+<?php get_footer(); ?>

--- a/farshid-terminal/page.php
+++ b/farshid-terminal/page.php
@@ -1,0 +1,13 @@
+<?php get_header(); ?>
+<main class="container py-5">
+<?php
+if ( have_posts() ) {
+    while ( have_posts() ) {
+        the_post();
+        echo '<h1>' . get_the_title() . '</h1>';
+        the_content();
+    }
+}
+?>
+</main>
+<?php get_footer(); ?>

--- a/farshid-terminal/parts/footer.html
+++ b/farshid-terminal/parts/footer.html
@@ -1,0 +1,3 @@
+<footer>
+    &copy; <!-- wp:site-title /-->.
+</footer>

--- a/farshid-terminal/parts/header.html
+++ b/farshid-terminal/parts/header.html
@@ -1,0 +1,13 @@
+<header class="farshid_terminal_header">
+    <div class="farshid_logo"><!-- wp:site-title /--></div>
+    <div class="farshid_header_controls">
+        <input type="text" class="farshid_search" placeholder="Search...">
+        <button id="farshid_daynight_btn" class="farshid_daynight_btn">&#9790;</button>
+    </div>
+</header>
+<div class="farshid_terminal_help">Type 'help' to see available commands</div>
+<div id="farshid_terminal_output" class="farshid_terminal_output"></div>
+<div class="farshid_terminal_input_row">
+    <div class="farshid_terminal_prompt">&gt;</div>
+    <input id="farshid_terminal_input" class="farshid_terminal_input" type="text" placeholder="Type your command...">
+</div>

--- a/farshid-terminal/searchform.php
+++ b/farshid-terminal/searchform.php
@@ -1,0 +1,7 @@
+<form role="search" method="get" class="search-form" action="<?php echo esc_url( home_url( '/' ) ); ?>">
+    <label>
+        <span class="screen-reader-text">Search for:</span>
+        <input type="search" class="search-field" placeholder="Search …" value="<?php echo get_search_query(); ?>" name="s" />
+    </label>
+    <button type="submit" class="search-submit">Search</button>
+</form>

--- a/farshid-terminal/single.php
+++ b/farshid-terminal/single.php
@@ -1,0 +1,16 @@
+<?php get_header(); ?>
+<main class="container py-5">
+<?php
+if ( have_posts() ) {
+    while ( have_posts() ) {
+        the_post();
+        echo '<h1>' . get_the_title() . '</h1>';
+        the_content();
+        if ( comments_open() || get_comments_number() ) {
+            comments_template();
+        }
+    }
+}
+?>
+</main>
+<?php get_footer(); ?>

--- a/farshid-terminal/style.css
+++ b/farshid-terminal/style.css
@@ -1,0 +1,10 @@
+/*
+Theme Name: Farshid Terminal
+Theme URI: https://example.com/farshid-terminal
+Author: Farshid
+Description: Terminal style WordPress theme with Full Site Editing support.
+Version: 1.0
+Requires at least: 6.4
+*/
+
+@import url('assets/css/terminal.css');

--- a/farshid-terminal/templates/index.html
+++ b/farshid-terminal/templates/index.html
@@ -1,0 +1,2 @@
+<!-- wp:template-part {"slug":"header"} /-->
+<!-- wp:template-part {"slug":"footer"} /-->

--- a/farshid-terminal/theme.json
+++ b/farshid-terminal/theme.json
@@ -1,0 +1,30 @@
+{
+  "version": 2,
+  "settings": {
+    "color": {
+      "custom": true,
+      "customGradient": true,
+      "customDuotone": true,
+      "customText": true,
+      "customBackground": true,
+      "palette": [
+        {"slug": "green", "color": "#0f0", "name": "Green"},
+        {"slug": "black", "color": "#000", "name": "Black"},
+        {"slug": "white", "color": "#fff", "name": "White"}
+      ]
+    },
+    "typography": {
+      "customFontSize": true
+    }
+  },
+  "styles": {
+    "color": {
+      "text": "#0f0",
+      "background": "#000"
+    }
+  },
+  "templateParts": [
+    {"name": "header", "title": "Header", "area": "header"},
+    {"name": "footer", "title": "Footer", "area": "footer"}
+  ]
+}


### PR DESCRIPTION
## Summary
- add Farshid Terminal block theme with FSE support
- include JS terminal logic for commands, pagination, search, and dark/light toggle
- style the theme to match the original terminal look
- provide templates for posts, pages and archives

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684842bdae848326a5308bc2e622020b