### PR TITLE
Add WordPress templates

### DIFF
--- a/archive.php
+++ b/archive.php
@@ -1,0 +1,8 @@
+<?php get_header(); ?>
+<div class="farshid_terminal_output">
+<h1><?php the_archive_title(); ?></h1>
+<?php if (have_posts()): while (have_posts()): the_post(); ?>
+    <div><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></div>
+<?php endwhile; the_posts_pagination(); endif; ?>
+</div>
+<?php get_footer(); ?>

--- a/category.php
+++ b/category.php
@@ -1,0 +1,8 @@
+<?php get_header(); ?>
+<div class="farshid_terminal_output">
+<h1><?php single_cat_title(); ?></h1>
+<?php if (have_posts()): while (have_posts()): the_post(); ?>
+    <div><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></div>
+<?php endwhile; the_posts_pagination(); endif; ?>
+</div>
+<?php get_footer(); ?>

--- a/comments.php
+++ b/comments.php
@@ -1,0 +1,11 @@
+<?php if (post_password_required()) return; ?>
+<div id="comments" class="farshid_comments">
+<?php if (have_comments()): ?>
+    <h2><?php comments_number(); ?></h2>
+    <ol class="comment-list">
+        <?php wp_list_comments(); ?>
+    </ol>
+<?php endif; ?>
+<?php comment_form(); ?>
+</div>
+

--- a/footer.php
+++ b/footer.php
@@ -1,0 +1,6 @@
+<footer>
+    © <?php echo date('Y'); ?> <?php bloginfo('name'); ?>. All rights reserved.
+</footer>
+<?php wp_footer(); ?>
+</body>
+</html>

--- a/header.php
+++ b/header.php
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title><?php bloginfo('name'); ?></title>
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+<link rel='stylesheet' href='<?php echo esc_url( get_stylesheet_uri() ); ?>'>
+<?php wp_head(); ?>
+</head>
+<body <?php body_class(); ?>>
+<header class="farshid_terminal_header">
+    <div class="farshid_logo"><?php bloginfo('name'); ?></div>
+    <div class="farshid_header_controls">
+        <form role="search" method="get" class="searchform" action="<?php echo esc_url( home_url( '/' ) ); ?>">
+            <input class="farshid_search" type="text" name="s" placeholder="Search..." value="<?php echo get_search_query(); ?>" />
+        </form>
+        <button id="farshid_daynight_btn" class="farshid_daynight_btn">&#9790;</button>
+    </div>
+</header>

--- a/index.php
+++ b/index.php
@@ -1,225 +1,129 @@
-<!DOCTYPE html>
-<html lang="en">
-
-<head>
-<meta charset="UTF-8">
-<title>Farshid Terminal</title>
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
-<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
-<style>
-    html, body {
-        height: 100%;
-        margin: 0;
-    }
-
-    body {
-        background-color: #000;
-        color: #0f0;
-        font-family: monospace;
-    }
-
-    .farshid_terminal_header {
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-        padding: 0.5rem 1rem;
-        background-color: #111;
-        color: #0f0;
-    }
-
-    .farshid_logo {
-        font-weight: bold;
-        font-size: 1.2rem;
-    }
-
-    .farshid_header_controls {
-        display: flex;
-        align-items: center;
-        gap: 0.2rem;
-    }
-
-    .farshid_search {
-        border: 1px solid #0f0;
-        background: transparent;
-        color: #0f0;
-        padding: 0.3rem 0.6rem;
-        border-radius: 0.25rem;
-    }
-
-    .farshid_daynight_btn {
-        cursor: pointer;
-        background: none;
-        border: none;
-        color: #0f0;
-        font-size: 1.2rem;
-    }
-
-    .farshid_terminal_output {
-        flex: 1;
-        overflow-y: auto;
-        white-space: pre-wrap;
-        display: flex;
-        flex-direction: column;
-        padding: 1rem;
-    }
-
-    .farshid_terminal_block {
-        margin-bottom: 0.3rem;
-    }
-
-    .farshid_terminal_command {
-        color: cyan;
-    }
-
-    .farshid_terminal_result {
-        color: #0f0;
-    }
-
-    .farshid_terminal_input_row {
-        display: flex;
-        align-items: center;
-        padding: 0 1rem 1rem;
-    }
-
-    .farshid_terminal_prompt {
-        margin-right: 0.5rem;
-    }
-
-    .farshid_terminal_input {
-        border: none;
-        outline: none;
-        background: transparent;
-        color: #0f0;
-        flex: 1;
-        font-family: monospace;
-    }
-
-    .farshid_terminal_help {
-        padding: 0 1rem;
-        color: #0f0;
-        margin-top: 0.5rem;
-        font-size: 0.9rem;
-    }
-
-    footer {
-        background: #111;
-        color: #0f0;
-        text-align: center;
-        padding: 0.5rem;
-        font-size: 0.85rem;
-    }
-
-    .dark-mode {
-        background-color: #000 !important;
-        color: #0f0 !important;
-    }
-
-    .light-mode {
-        background-color: #f0f0f0 !important;
-        color: #000 !important;
-    }
-
-    .light-mode input.farshid_search,
-    .light-mode .farshid_terminal_input {
-        color: #000 !important;
-        border-color: #000 !important;
-    }
-
-    .light-mode footer {
-        background: #ccc !important;
-        color: #000 !important;
-    }
-
-    .light-mode .farshid_terminal_header {
-        background-color: #ddd !important;
-        color: #000 !important;
-    }
-</style>
-</head>
-
-<body>
-<header class="farshid_terminal_header">
-    <div class="farshid_logo">Farshid Terminal</div>
-    <div class="farshid_header_controls">
-        <input type="text" class="farshid_search" placeholder="Search...">
-        <button id="farshid_daynight_btn" class="farshid_daynight_btn">&#9790;</button>
-    </div>
-</header>
-
-<div class="farshid_terminal_help">Type 'help' to see available commands</div>
-
+<?php get_header(); ?>
+<div class="farshid_terminal_help">Type 'help' for pages or 'posts' to view posts</div>
 <div id="farshid_terminal_output" class="farshid_terminal_output"></div>
-
 <div class="farshid_terminal_input_row">
     <div class="farshid_terminal_prompt">&gt;</div>
     <input id="farshid_terminal_input" class="farshid_terminal_input" type="text" placeholder="Type your command...">
 </div>
-
-<footer>
-    © 2025 Farshid Terminal. All rights reserved.
-</footer>
-
 <script>
-    const farshid_output = document.getElementById('farshid_terminal_output');
-    const farshid_input = document.getElementById('farshid_terminal_input');
-    const farshid_daynight_btn = document.getElementById('farshid_daynight_btn');
+const farshid_output = document.getElementById('farshid_terminal_output');
+const farshid_input = document.getElementById('farshid_terminal_input');
+const farshid_daynight_btn = document.getElementById('farshid_daynight_btn');
 
-    function farshid_addBlock(command, output, isWarning = false) {
-        const block = document.createElement('div');
-        block.className = 'farshid_terminal_block';
-
-        const cmdLine = document.createElement('div');
-        cmdLine.className = 'farshid_terminal_command';
-        cmdLine.textContent = `> ${command}`;
-
-        const resultLine = document.createElement('div');
-        resultLine.className = 'farshid_terminal_result';
-        resultLine.textContent = output;
-        if (isWarning) {
-            resultLine.style.color = 'yellow';
-        }
-
-        block.appendChild(cmdLine);
-        block.appendChild(resultLine);
-
-        farshid_output.appendChild(block);
-        farshid_output.scrollTop = farshid_output.scrollHeight;
+const farshid_pages = <?php
+    $pages = get_pages();
+    $pages_data = [];
+    foreach ($pages as $p) {
+        $pages_data[$p->post_title] = apply_filters('the_content', $p->post_content);
     }
+    echo json_encode($pages_data);
+?>;
+const farshid_posts = <?php
+    $posts_query = new WP_Query(['posts_per_page' => 100]);
+    $posts_data = [];
+    if ($posts_query->have_posts()):
+        while ($posts_query->have_posts()): $posts_query->the_post();
+            $posts_data[] = [
+                'title' => get_the_title(),
+                'link'  => get_permalink(),
+                'categories' => wp_get_post_categories(get_the_ID(), ['fields' => 'names'])
+            ];
+        endwhile;
+        wp_reset_postdata();
+    endif;
+    echo json_encode($posts_data);
+?>;
+const farshid_categories = <?php
+    $categories = get_categories(['hide_empty' => 0]);
+    $cats = [];
+    foreach ($categories as $c) {
+        $query = new WP_Query(['cat' => $c->term_id, 'posts_per_page' => 100]);
+        $posts = [];
+        while ($query->have_posts()) { $query->the_post(); $posts[] = ['title'=>get_the_title(), 'link'=>get_permalink()]; }
+        wp_reset_postdata();
+        $cats[$c->name] = $posts;
+    }
+    echo json_encode($cats);
+?>;
+let farshid_current_page = 0;
+const farshid_posts_per_page = 10;
+const farshid_post_lookup = {};
+farshid_posts.forEach(p => { farshid_post_lookup[p.title] = p; });
 
-    function farshid_handleCommand(cmd) {
-        if (cmd === 'help') {
-            return 'Available commands:\nhelp - show this message\nclear - clear the terminal';
-        } else if (cmd === 'clear') {
-            farshid_output.innerHTML = '';
-            return '';
-        } else {
-            return `Command not found: ${cmd}`;
+function farshid_addBlock(command, output, isWarning = false) {
+    const block = document.createElement('div');
+    block.className = 'farshid_terminal_block';
+    const cmdLine = document.createElement('div');
+    cmdLine.className = 'farshid_terminal_command';
+    cmdLine.textContent = `> ${command}`;
+    const resultLine = document.createElement('div');
+    resultLine.className = 'farshid_terminal_result';
+    resultLine.innerHTML = output;
+    if (isWarning) resultLine.style.color = 'yellow';
+    block.appendChild(cmdLine);
+    block.appendChild(resultLine);
+    farshid_output.appendChild(block);
+    farshid_output.scrollTop = farshid_output.scrollHeight;
+}
+
+function farshid_renderPosts() {
+    const start = farshid_current_page * farshid_posts_per_page;
+    const end = start + farshid_posts_per_page;
+    const postsSlice = farshid_posts.slice(start, end);
+    if (postsSlice.length === 0) return 'No posts';
+    let output = postsSlice.map(p => `- ${p.title} (${p.link})`).join('\n');
+    if (farshid_posts.length > farshid_posts_per_page) {
+        output += '\nType "next" or "prev" to navigate.';
+    }
+    return output;
+}
+
+function farshid_handleCommand(cmd) {
+    if (cmd === 'help') {
+        return 'Pages:\n' + Object.keys(farshid_pages).join('\n');
+    } else if (cmd === 'posts') {
+        farshid_current_page = 0;
+        return farshid_renderPosts();
+    } else if (cmd === 'next') {
+        if ((farshid_current_page + 1) * farshid_posts_per_page < farshid_posts.length) {
+            farshid_current_page++;
+            return farshid_renderPosts();
+        }
+        return 'No more posts';
+    } else if (cmd === 'prev') {
+        if (farshid_current_page > 0) {
+            farshid_current_page--;
+            return farshid_renderPosts();
+        }
+        return 'No previous posts';
+    } else if (farshid_pages[cmd]) {
+        return farshid_pages[cmd];
+    } else if (farshid_categories[cmd]) {
+        const posts = farshid_categories[cmd];
+        return posts.map(p => `- ${p.title} (${p.link})`).join('\n');
+    } else if (farshid_post_lookup[cmd]) {
+        window.location.href = farshid_post_lookup[cmd].link;
+        return 'Opening post...';
+    }
+    return `Command not found: ${cmd}`;
+}
+
+farshid_input.addEventListener('keydown', function(e) {
+    if (e.key === 'Enter') {
+        const cmd = farshid_input.value.trim();
+        if (cmd) {
+            const output = farshid_handleCommand(cmd);
+            const isWarning = output.startsWith('Command not found');
+            if (output) farshid_addBlock(cmd, output, isWarning);
+            farshid_input.value = '';
         }
     }
+});
 
-    farshid_input.addEventListener('keydown', function (e) {
-        if (e.key === 'Enter') {
-            const cmd = farshid_input.value.trim();
-            if (cmd) {
-                const output = farshid_handleCommand(cmd);
-                if (cmd !== 'clear') {
-                    const isWarning = output.startsWith('Command not found');
-                    farshid_addBlock(cmd, output, isWarning);
-                }
-                farshid_input.value = '';
-            }
-        }
-    });
-
-    // Day/Night mode toggle
-    farshid_daynight_btn.addEventListener('click', function () {
-        document.body.classList.toggle('light-mode');
-        if (document.body.classList.contains('light-mode')) {
-            farshid_daynight_btn.innerHTML = '&#9728;'; // sun
-        } else {
-            farshid_daynight_btn.innerHTML = '&#9790;'; // moon
-        }
-    });
+farshid_daynight_btn.addEventListener('click', function() {
+    document.body.classList.toggle('light-mode');
+    farshid_daynight_btn.innerHTML = document.body.classList.contains('light-mode') ? '&#9728;' : '&#9790;';
+});
 </script>
-</body>
-</html>
+<?php get_footer(); ?>
+

--- a/page.php
+++ b/page.php
@@ -1,0 +1,11 @@
+<?php get_header(); ?>
+<div class="farshid_terminal_output">
+<?php
+while (have_posts()): the_post();
+    echo '<h1>' . get_the_title() . '</h1>';
+    the_content();
+    comments_template();
+endwhile;
+?>
+</div>
+<?php get_footer(); ?>

--- a/single.php
+++ b/single.php
@@ -1,0 +1,11 @@
+<?php get_header(); ?>
+<div class="farshid_terminal_output">
+<?php
+while (have_posts()): the_post();
+    echo '<h1>' . get_the_title() . '</h1>';
+    the_content();
+    comments_template();
+endwhile;
+?>
+</div>
+<?php get_footer(); ?>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,158 @@
+/*
+Theme Name: Terminal WordPress
+Author: Farshid
+Description: Terminal-style interface theme with pagination commands.
+Version: 1.0
+*/
+
+    html, body {
+        height: 100%;
+        margin: 0;
+    }
+
+    body {
+        background-color: #000;
+        color: #0f0;
+        font-family: monospace;
+    }
+
+    .farshid_terminal_header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        padding: 0.5rem 1rem;
+        background-color: #111;
+        color: #0f0;
+    }
+
+    .farshid_logo {
+        font-weight: bold;
+        font-size: 1.2rem;
+    }
+
+    .farshid_header_controls {
+        display: flex;
+        align-items: center;
+        gap: 0.2rem;
+    }
+
+    .farshid_search {
+        border: 1px solid #0f0;
+        background: transparent;
+        color: #0f0;
+        padding: 0.3rem 0.6rem;
+        border-radius: 0.25rem;
+    }
+
+    .farshid_daynight_btn {
+        cursor: pointer;
+        background: none;
+        border: none;
+        color: #0f0;
+        font-size: 1.2rem;
+    }
+
+    .farshid_terminal_output {
+        flex: 1;
+        overflow-y: auto;
+        white-space: pre-wrap;
+        display: flex;
+        flex-direction: column;
+        padding: 1rem;
+    }
+
+    .farshid_terminal_block {
+        margin-bottom: 0.3rem;
+    }
+
+    .farshid_terminal_command {
+        color: cyan;
+    }
+
+    .farshid_terminal_result {
+        color: #0f0;
+    }
+
+    .farshid_terminal_input_row {
+        display: flex;
+        align-items: center;
+        padding: 0 1rem 1rem;
+    }
+
+    .farshid_terminal_prompt {
+        margin-right: 0.5rem;
+    }
+
+    .farshid_terminal_input {
+        border: none;
+        outline: none;
+        background: transparent;
+        color: #0f0;
+        flex: 1;
+        font-family: monospace;
+    }
+
+    .farshid_terminal_help {
+        padding: 0 1rem;
+        color: #0f0;
+        margin-top: 0.5rem;
+        font-size: 0.9rem;
+    }
+
+    footer {
+        background: #111;
+        color: #0f0;
+        text-align: center;
+        padding: 0.5rem;
+        font-size: 0.85rem;
+    }
+
+    .dark-mode {
+        background-color: #000 !important;
+        color: #0f0 !important;
+    }
+
+    .light-mode {
+        background-color: #f0f0f0 !important;
+        color: #000 !important;
+    }
+
+    .light-mode input.farshid_search,
+    .light-mode .farshid_terminal_input {
+        color: #000 !important;
+        border-color: #000 !important;
+    }
+
+    .light-mode footer {
+        background: #ccc !important;
+        color: #000 !important;
+    }
+
+    .light-mode .farshid_terminal_header {
+        background-color: #ddd !important;
+        color: #000 !important;
+    }
+
+    a {
+        color: #0ff;
+    }
+
+    a:hover {
+        color: yellow;
+    }
+
+    .farshid_comments {
+        padding: 1rem;
+    }
+
+    .farshid_comments .comment-list {
+        list-style: none;
+        padding-left: 0;
+    }
+
+    .farshid_comments .comment-list li {
+        margin-bottom: 0.5rem;
+        border-bottom: 1px dashed #0f0;
+        padding-bottom: 0.5rem;
+    }
+


### PR DESCRIPTION
## Summary
- refactor `index.php` to use `get_header()` and `get_footer()`
- implement terminal-style `header.php` and `footer.php`
- add `single.php`, `page.php`, `category.php`, and `archive.php`
- include `comments.php` for styled comments
- enhance JavaScript commands for pages, posts, and categories
- extend terminal stylesheet

## Testing
- `php -l index.php` *(fails: command not found)*
- `php -l single.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684de6787a108326a198db340567f24e