### PR TITLE
Fix post link display in terminal interface

### DIFF
--- a/index.php
+++ b/index.php
@@ -54,7 +54,7 @@
 
         const resultLine = document.createElement('div');
         resultLine.className = 'farshid_terminal_result';
-        resultLine.textContent = output;
+        resultLine.innerHTML = output;
         if (isWarning) {
             resultLine.style.color = 'yellow';
         }


### PR DESCRIPTION
## Summary
- ensure HTML returned by commands is rendered as markup

## Testing
- `php -l index.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dee68d9fc83269a1e1f704268b4ce