### PR TITLE
Limit help prompt to home page

### DIFF
--- a/header.php
+++ b/header.php
@@ -18,4 +18,3 @@
         <button id="farshid_daynight_btn" class="farshid_daynight_btn">&#9790;</button>
     </div>
 </header>
-<div class="farshid_terminal_help">Type 'help' for pages or 'posts' to view posts</div>

--- a/index.php
+++ b/index.php
@@ -1,5 +1,5 @@
 <?php get_header(); ?>
-
+<div class="farshid_terminal_help">Type 'help' for pages or 'posts' to view posts</div>
 <div id="farshid_terminal_output" class="farshid_terminal_output"></div>
 
 <div class="farshid_terminal_input_row">


### PR DESCRIPTION
## Summary
- show the `Type 'help'` prompt only on the home page

## Testing
- `php -l index.php` *(fails: command not found)*
- `php -l header.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684df7854760832698efb654a9c3f628