### PR TITLE
Refine terminal search results

### DIFF
--- a/search.php
+++ b/search.php
@@ -1,14 +1,19 @@
 <?php get_header(); ?>
-<div class="farshid_terminal_output">
-<h1><?php printf( __('Search Results for: %s'), get_search_query() ); ?></h1>
-<?php if ( have_posts() ) : ?>
-    <ul>
-    <?php while ( have_posts() ) : the_post(); ?>
-        <li><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></li>
-    <?php endwhile; ?>
-    </ul>
-<?php else : ?>
-    <p><?php _e('No posts found'); ?></p>
-<?php endif; ?>
+<div class="farshid_terminal_output farshid_search_results">
+    <h1><?php printf( __('Search Results for: %s'), get_search_query() ); ?></h1>
+    <?php if ( have_posts() ) : ?>
+        <ul class="farshid_terminal_list">
+        <?php while ( have_posts() ) : the_post(); ?>
+            <li>
+                - <a href="<?php the_permalink(); ?>" class="farshid_post_link"><?php the_title(); ?></a>
+                <span class="farshid_search_excerpt"><?php echo strip_tags( get_the_excerpt() ); ?></span>
+            </li>
+        <?php endwhile; ?>
+        </ul>
+    <?php else : ?>
+        <div class="farshid_terminal_block">
+            <div class="farshid_terminal_result"><?php _e('No posts found'); ?></div>
+        </div>
+    <?php endif; ?>
 </div>
 <?php get_footer(); ?>

--- a/style.css
+++ b/style.css
@@ -69,8 +69,17 @@ Version: 1.0
         color: cyan;
     }
 
-    .farshid_terminal_result {
+.farshid_terminal_result {
         color: #0f0;
+    }
+
+    .farshid_terminal_list {
+        list-style: none;
+        padding-left: 0;
+    }
+
+    .farshid_terminal_list li {
+        margin-bottom: 0.3rem;
     }
 
     .farshid_terminal_input_row {
@@ -150,6 +159,16 @@ Version: 1.0
         color: cyan;
         text-decoration: underline;
         cursor: pointer;
+    }
+
+    .farshid_search_excerpt {
+        margin-left: 0.5rem;
+        font-size: 0.9rem;
+    }
+
+    .farshid_search_excerpt p {
+        margin: 0;
+        display: inline;
     }
 
     /* Comment form styled like terminal search box */


### PR DESCRIPTION
## Summary
- improve search results layout using terminal blocks
- style search excerpts

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684df872557083269f414ac2aec82be4