### PR TITLE
Fix whitespace in search results

### DIFF
--- a/style.css
+++ b/style.css
@@ -61,6 +61,11 @@ Version: 1.0
         padding: 1rem;
     }
 
+    /* Search results should not preserve extra whitespace */
+    .farshid_search_results {
+        white-space: normal;
+    }
+
     .farshid_terminal_block {
         margin-bottom: 0.3rem;
     }


### PR DESCRIPTION
## Summary
- avoid whitespace preservation in the search result container

## Testing
- `php -l search.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dfac408a48326b5acd9886345559b