### PR TITLE
Add localization support

### DIFF
--- a/archive.php
+++ b/archive.php
@@ -9,7 +9,7 @@
     </ul>
     <?php the_posts_pagination(); ?>
 <?php else : ?>
-    <p><?php _e('No posts found'); ?></p>
+    <p><?php _e('No posts found', 'terminal'); ?></p>
 <?php endif; ?>
 </div>
 <?php get_footer(); ?>

--- a/category.php
+++ b/category.php
@@ -9,7 +9,7 @@
     </ul>
     <?php the_posts_pagination(); ?>
 <?php else : ?>
-    <p><?php _e('No posts found'); ?></p>
+    <p><?php _e('No posts found', 'terminal'); ?></p>
 <?php endif; ?>
 </div>
 <?php get_footer(); ?>

--- a/footer.php
+++ b/footer.php
@@ -1,5 +1,5 @@
 <footer>
-    © <?php echo date('Y'); ?> <?php bloginfo('name'); ?>. All rights reserved.
+    <?php printf( esc_html__('© %1$s %2$s. All rights reserved.', 'terminal'), date('Y'), get_bloginfo('name') ); ?>
 </footer>
 
 <script>

--- a/functions.php
+++ b/functions.php
@@ -1,5 +1,6 @@
 <?php
 function terminal_setup() {
+    load_theme_textdomain('terminal', get_template_directory() . '/languages');
     add_theme_support('title-tag');
     add_theme_support('post-thumbnails');
 }

--- a/header.php
+++ b/header.php
@@ -13,7 +13,7 @@
     <div class="farshid_logo"><?php bloginfo('name'); ?></div>
     <div class="farshid_header_controls">
         <form role="search" method="get" class="searchform" action="<?php echo esc_url( home_url( '/' ) ); ?>">
-            <input class="farshid_search" type="text" name="s" placeholder="Search..." value="<?php echo get_search_query(); ?>" />
+            <input class="farshid_search" type="text" name="s" placeholder="<?php esc_attr_e('Search...', 'terminal'); ?>" value="<?php echo get_search_query(); ?>" />
         </form>
         <button id="farshid_daynight_btn" class="farshid_daynight_btn">&#9790;</button>
     </div>

--- a/index.php
+++ b/index.php
@@ -1,20 +1,31 @@
 <?php get_header(); ?>
-<div class="farshid_terminal_help">Type 'help' for pages or 'posts' to view posts</div>
+<div class="farshid_terminal_help"><?php esc_html_e("Type 'help' for pages or 'posts' to view posts", 'terminal'); ?></div>
 <div id="farshid_terminal_output" class="farshid_terminal_output"></div>
 
 <div class="farshid_terminal_input_row">
     <div class="farshid_terminal_prompt">&gt;</div>
-    <input id="farshid_terminal_input" class="farshid_terminal_input" type="text" placeholder="Type your command...">
+    <input id="farshid_terminal_input" class="farshid_terminal_input" type="text" placeholder="<?php esc_attr_e('Type your command...', 'terminal'); ?>">
 </div>
 
 <footer>
-    © <?php echo date('Y'); ?> <?php bloginfo('name'); ?>. All rights reserved.
+    <?php printf( esc_html__('© %1$s %2$s. All rights reserved.', 'terminal'), date('Y'), get_bloginfo('name') ); ?>
 </footer>
 
 <script>
     const farshid_output = document.getElementById('farshid_terminal_output');
     const farshid_input = document.getElementById('farshid_terminal_input');
     const farshid_daynight_btn = document.getElementById('farshid_daynight_btn');
+
+    const terminal_i18n = {
+        no_posts: '<?php echo esc_js( __( 'No posts', 'terminal' ) ); ?>',
+        categories: '<?php echo esc_js( __( 'Categories', 'terminal' ) ); ?>',
+        navigate: '<?php echo esc_js( __( 'Type "next" or "prev" to navigate.', 'terminal' ) ); ?>',
+        help: '<?php echo esc_js( __( 'Pages:\n%PAGES%\nCategories:\n%CATEGORIES%\nCommands:\nhelp - list pages\nposts - show recent posts', 'terminal' ) ); ?>',
+        no_more_posts: '<?php echo esc_js( __( 'No more posts', 'terminal' ) ); ?>',
+        no_previous_posts: '<?php echo esc_js( __( 'No previous posts', 'terminal' ) ); ?>',
+        no_content: '<?php echo esc_js( __( 'No content', 'terminal' ) ); ?>',
+        command_not_found: '<?php echo esc_js( __( 'Command not found: %s', 'terminal' ) ); ?>'
+    };
 
     const farshid_pages = <?php
         $pages = get_pages();
@@ -71,14 +82,14 @@
         const end = start + farshid_posts_per_page;
         const postsSlice = farshid_posts.slice(start, end);
         if (postsSlice.length === 0) {
-            return 'No posts';
+            return terminal_i18n.no_posts;
         }
         let output = postsSlice
             .map(p => `- <a href="${p.link}" class='farshid_post_link' target='_blank'>${p.title}</a>`)
             .join('<br>');
-        output += '<br>Categories: ' + farshid_categories.map(c => c.name).join(', ');
+        output += '<br>' + terminal_i18n.categories + ': ' + farshid_categories.map(c => c.name).join(', ');
         if (farshid_posts.length > farshid_posts_per_page) {
-            output += '<br>Type "next" or "prev" to navigate.';
+            output += '<br>' + terminal_i18n.navigate;
         }
         return output;
     }
@@ -88,7 +99,7 @@
         if (cmd === 'help') {
             const pages = farshid_pages.map(p => p.title).join('\n');
             const cats = farshid_categories.map(c => c.name).join('\n');
-            return 'Pages:\n' + pages + '\nCategories:\n' + cats + '\nCommands:\nhelp - list pages\nposts - show recent posts';
+            return terminal_i18n.help.replace('%PAGES%', pages).replace('%CATEGORIES%', cats);
         } else if (cmd === 'posts') {
             farshid_current_page = 0;
             return farshid_renderPosts();
@@ -97,13 +108,13 @@
                 farshid_current_page++;
                 return farshid_renderPosts();
             }
-            return 'No more posts';
+            return terminal_i18n.no_more_posts;
         } else if (cmd === 'prev') {
             if (farshid_current_page > 0) {
                 farshid_current_page--;
                 return farshid_renderPosts();
             }
-            return 'No previous posts';
+            return terminal_i18n.no_previous_posts;
         } else if (farshid_posts.find(p => p.title.toLowerCase() === lowerCmd)) {
             const post = farshid_posts.find(p => p.title.toLowerCase() === lowerCmd);
             window.location = post.link;
@@ -115,7 +126,7 @@
                 .then(html => {
                     const doc = new DOMParser().parseFromString(html, 'text/html');
                     const content = doc.querySelector('.farshid_terminal_output');
-                    farshid_addBlock(cmd, content ? content.textContent.trim() : 'No content');
+                    farshid_addBlock(cmd, content ? content.textContent.trim() : terminal_i18n.no_content);
                 });
             return '';
         } else if (farshid_categories.find(c => c.name.toLowerCase() === lowerCmd)) {
@@ -125,11 +136,11 @@
                 .then(html => {
                     const doc = new DOMParser().parseFromString(html, 'text/html');
                     const content = doc.querySelector('.farshid_terminal_output');
-                    farshid_addBlock(cmd, content ? content.textContent.trim() : 'No content');
+                    farshid_addBlock(cmd, content ? content.textContent.trim() : terminal_i18n.no_content);
                 });
             return '';
         } else {
-            return `Command not found: ${cmd}`;
+            return terminal_i18n.command_not_found.replace('%s', cmd);
         }
     }
 
@@ -138,7 +149,7 @@
             const cmd = farshid_input.value.trim();
             if (cmd) {
                 const output = farshid_handleCommand(cmd);
-                const isWarning = output.startsWith('Command not found');
+                const isWarning = output.startsWith(terminal_i18n.command_not_found.replace('%s', '').trim());
                 if (output) {
                     farshid_addBlock(cmd, output, isWarning);
                 }

--- a/languages/terminal-en_US.po
+++ b/languages/terminal-en_US.po
@@ -1,0 +1,46 @@
+msgid ""
+msgstr ""
+"Language: en_US\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+
+msgid "Search Results for: %s"
+msgstr "Search Results for: %s"
+
+msgid "No posts found"
+msgstr "No posts found"
+
+msgid "Type 'help' for pages or 'posts' to view posts"
+msgstr "Type 'help' for pages or 'posts' to view posts"
+
+msgid "Type your command..."
+msgstr "Type your command..."
+
+msgid "© %1$s %2$s. All rights reserved."
+msgstr "© %1$s %2$s. All rights reserved."
+
+msgid "No posts"
+msgstr "No posts"
+
+msgid "Categories"
+msgstr "Categories"
+
+msgid "Type \"next\" or \"prev\" to navigate."
+msgstr "Type \"next\" or \"prev\" to navigate."
+
+msgid "Pages:\n%PAGES%\nCategories:\n%CATEGORIES%\nCommands:\nhelp - list pages\nposts - show recent posts"
+msgstr "Pages:\n%PAGES%\nCategories:\n%CATEGORIES%\nCommands:\nhelp - list pages\nposts - show recent posts"
+
+msgid "No more posts"
+msgstr "No more posts"
+
+msgid "No previous posts"
+msgstr "No previous posts"
+
+msgid "No content"
+msgstr "No content"
+
+msgid "Command not found: %s"
+msgstr "Command not found: %s"
+
+msgid "Search..."
+msgstr "Search..."

--- a/languages/terminal-fa_IR.po
+++ b/languages/terminal-fa_IR.po
@@ -1,0 +1,46 @@
+msgid ""
+msgstr ""
+"Language: fa_IR\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+
+msgid "Search Results for: %s"
+msgstr "نتایج جستجو برای: %s"
+
+msgid "No posts found"
+msgstr "هیچ نوشته‌ای یافت نشد"
+
+msgid "Type 'help' for pages or 'posts' to view posts"
+msgstr "عبارت 'help' را برای فهرست صفحات یا 'posts' برای دیدن نوشته‌ها وارد کنید"
+
+msgid "Type your command..."
+msgstr "دستور خود را وارد کنید..."
+
+msgid "© %1$s %2$s. All rights reserved."
+msgstr "© %1$s %2$s. تمامی حقوق محفوظ است."
+
+msgid "No posts"
+msgstr "هیچ نوشته‌ای نیست"
+
+msgid "Categories"
+msgstr "دسته‌بندی‌ها"
+
+msgid "Type \"next\" or \"prev\" to navigate."
+msgstr "برای جابجایی \"next\" یا \"prev\" را وارد کنید."
+
+msgid "Pages:\n%PAGES%\nCategories:\n%CATEGORIES%\nCommands:\nhelp - list pages\nposts - show recent posts"
+msgstr "صفحات:\n%PAGES%\nدسته‌بندی‌ها:\n%CATEGORIES%\nدستورات:\nhelp - فهرست صفحات\nposts - نمایش نوشته‌های اخیر"
+
+msgid "No more posts"
+msgstr "نوشته دیگری نیست"
+
+msgid "No previous posts"
+msgstr "نوشته قبلی وجود ندارد"
+
+msgid "No content"
+msgstr "محتوایی وجود ندارد"
+
+msgid "Command not found: %s"
+msgstr "دستور یافت نشد: %s"
+
+msgid "Search..."
+msgstr "جستجو..."

--- a/search.php
+++ b/search.php
@@ -1,6 +1,6 @@
 <?php get_header(); ?>
 <div class="farshid_terminal_output farshid_search_results">
-    <h1><?php printf( __('Search Results for: %s'), get_search_query() ); ?></h1>
+    <h1><?php printf( __('Search Results for: %s', 'terminal'), get_search_query() ); ?></h1>
     <?php if ( have_posts() ) : ?>
         <?php while ( have_posts() ) : the_post(); ?>
             <div class="farshid_terminal_block">
@@ -15,7 +15,7 @@
         <?php the_posts_pagination(); ?>
     <?php else : ?>
         <div class="farshid_terminal_block">
-            <div class="farshid_terminal_result"><?php _e('No posts found'); ?></div>
+            <div class="farshid_terminal_result"><?php _e('No posts found', 'terminal'); ?></div>
         </div>
     <?php endif; ?>
 </div>

--- a/style.css
+++ b/style.css
@@ -3,6 +3,8 @@ Theme Name: Terminal WordPress
 Author: Farshid
 Description: Terminal-style interface theme with pagination commands.
 Version: 1.0
+Text Domain: terminal
+Domain Path: /languages
 */
 
     html, body {


### PR DESCRIPTION
## Summary
- add text domain info in `style.css`
- load text domain in `functions.php`
- make strings in templates translatable
- localize terminal UI strings with JS object
- provide English and Farsi translation files

## Testing
- `php` command not available; no tests run

------
https://chatgpt.com/codex/tasks/task_e_684dfc733abc8326a29e95f56c868fad