### PR TITLE
Remove inline styles and load dynamic CSS from separate file

### DIFF
--- a/custom-style.php
+++ b/custom-style.php
@@ -1,0 +1,10 @@
+<?php
+header('Content-Type: text/css; charset=utf-8');
+require_once dirname(__FILE__, 3) . '/wp-load.php';
+$bg = get_theme_mod('terminal_bg_color', '#000000');
+$text = get_theme_mod('terminal_text_color', '#00ff00');
+?>
+:root{
+    --terminal-bg-color: <?php echo esc_attr($bg); ?>;
+    --terminal-text-color: <?php echo esc_attr($text); ?>;
+}

--- a/functions.php
+++ b/functions.php
@@ -29,15 +29,9 @@ function terminal_customize_register($wp_customize) {
 }
 add_action('customize_register', 'terminal_customize_register');
 
-function terminal_customizer_css() {
-    $bg = get_theme_mod('terminal_bg_color', '#000000');
-    $text = get_theme_mod('terminal_text_color', '#00ff00');
-    echo '<style>body{--terminal-bg-color:' . esc_attr($bg) . ';--terminal-text-color:' . esc_attr($text) . ';}</style>';
-}
-add_action('wp_head', 'terminal_customizer_css');
-
 function terminal_enqueue_assets() {
     wp_enqueue_style('terminal-style', get_stylesheet_uri());
+    wp_enqueue_style('terminal-custom-style', get_template_directory_uri() . '/custom-style.php');
     wp_enqueue_script('terminal-script', get_template_directory_uri() . '/assets/main.js', array(), null, true);
 
     $pages = get_pages();


### PR DESCRIPTION
## Summary
- remove `terminal_customizer_css` function that injected inline `<style>`
- load dynamic CSS using `custom-style.php` so customization values are still respected
- enqueue the dynamic stylesheet in `functions.php`

## Testing
- `php` not available, so syntax not checked automatically

------
https://chatgpt.com/codex/tasks/task_e_684e0be2b3188326adec7db774bcc64e