### PR TITLE
Add CLI history script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# Terminal Utilities
+
+This repository contains a simple Node.js command-line tool.
+
+## CLI with History
+
+Run `node cli.js` to start an interactive prompt. Use the **up** and **down** arrow keys to navigate through the previous commands. The interface stores up to 10 commands per session.

--- a/cli.js
+++ b/cli.js
@@ -1,0 +1,20 @@
+const readline = require('readline');
+
+const rl = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout,
+  historySize: 10,
+  prompt: '> '
+});
+
+console.log('Simple CLI. Press up/down to navigate command history (max 10).');
+rl.prompt();
+
+rl.on('line', (line) => {
+  console.log(`You typed: ${line}`);
+  rl.prompt();
+}).on('close', () => {
+  console.log('Session ended');
+  process.exit(0);
+});
+


### PR DESCRIPTION
## Summary
- add Node.js CLI example with history navigation limited to 10 commands
- document the CLI script in README

## Testing
- `node cli.js </dev/null`
- ❌ `php -l index.php` *(failed: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684ebbd93ec083268f6d89cc04730e45