### PR TITLE
Improve CLI history script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# Terminal Utilities
+
+This repository contains a simple Node.js command-line tool.
+
+## CLI with History
+
+Run `node cli.js` to start an interactive prompt. Use the **up** and **down** arrow keys to move through your last commands. The prompt stores at most 10 commands for the current session. Press **Ctrl+C** to exit.

--- a/cli.js
+++ b/cli.js
@@ -1,0 +1,45 @@
+const readline = require('readline');
+readline.emitKeypressEvents(process.stdin);
+if (process.stdin.isTTY) process.stdin.setRawMode(true);
+
+const rl = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout,
+  prompt: '> '
+});
+
+const history = [];
+let historyIndex = 0;
+
+console.log('Simple CLI. Press up/down to navigate command history (max 10).');
+rl.prompt();
+
+process.stdin.on('keypress', (str, key) => {
+  if (key.name === 'up') {
+    if (historyIndex > 0) historyIndex--;
+    const cmd = history[historyIndex] || '';
+    rl.write(null, { ctrl: true, name: 'u' });
+    rl.write(cmd);
+  } else if (key.name === 'down') {
+    if (historyIndex < history.length) historyIndex++;
+    const cmd = history[historyIndex] || '';
+    rl.write(null, { ctrl: true, name: 'u' });
+    rl.write(cmd);
+  } else if (key.sequence === '\u0003') {
+    rl.close();
+  }
+});
+
+rl.on('line', line => {
+  const trimmed = line.trim();
+  if (trimmed) {
+    history.push(trimmed);
+    if (history.length > 10) history.shift();
+  }
+  historyIndex = history.length;
+  console.log(`You typed: ${line}`);
+  rl.prompt();
+}).on('close', () => {
+  console.log('Session ended');
+  process.exit(0);
+});


### PR DESCRIPTION
## Summary
- rework CLI script to explicitly track last 10 commands with arrow key navigation
- document CLI exit instructions

## Testing
- `node cli.js </dev/null`
- ❌ `php -l index.php` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ebbd93ec083268f6d89cc04730e45