### PR TITLE
Implement browser command history

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# Terminal Utilities
+
+This repository contains a simple Node.js command-line tool.
+
+## CLI with History
+
+Run `node cli.js` to start an interactive prompt showing the placeholder
+**"type your command"**. Each command you enter is stored in a history stack of
+up to 10 items. Press the **up** arrow to recall earlier commands and the
+**down** arrow to navigate forward. Press **Ctrl+C** to exit.
+
+## Browser Terminal Input
+
+The WordPress theme includes an input field with the same "type your command"
+placeholder. Up to 10 commands are stored per browser session using
+`sessionStorage`. Use the ArrowUp and ArrowDown keys to cycle through previous
+commands just like a terminal.

--- a/assets/main.js
+++ b/assets/main.js
@@ -17,6 +17,10 @@ document.addEventListener('DOMContentLoaded', function () {
     let farshid_current_page = 0;
     const farshid_posts_per_page = 10;
 
+    // Load command history from this session and track current index
+    let commandHistory = JSON.parse(sessionStorage.getItem('terminalHistory') || '[]');
+    let historyIndex = commandHistory.length;
+
     function farshid_addBlock(command, output, isWarning = false) {
         const block = document.createElement('div');
         block.className = 'farshid_terminal_block';
@@ -111,10 +115,36 @@ document.addEventListener('DOMContentLoaded', function () {
             const cmd = farshid_input.value.trim();
             if (cmd) {
                 const output = farshid_handleCommand(cmd);
-                const isWarning = output.startsWith(terminal_i18n.command_not_found.replace('%s', '').trim());
+                const isWarning = output.startsWith(
+                    terminal_i18n.command_not_found.replace('%s', '').trim()
+                );
                 if (output) {
                     farshid_addBlock(cmd, output, isWarning);
                 }
+
+                // Store command in history and cap at 10 items
+                commandHistory.push(cmd);
+                if (commandHistory.length > 10) {
+                    commandHistory.shift();
+                }
+                sessionStorage.setItem('terminalHistory', JSON.stringify(commandHistory));
+                historyIndex = commandHistory.length;
+
+                farshid_input.value = '';
+            }
+        } else if (e.key === 'ArrowUp') {
+            e.preventDefault();
+            if (historyIndex > 0) {
+                historyIndex--;
+                farshid_input.value = commandHistory[historyIndex] || '';
+            }
+        } else if (e.key === 'ArrowDown') {
+            e.preventDefault();
+            if (historyIndex < commandHistory.length - 1) {
+                historyIndex++;
+                farshid_input.value = commandHistory[historyIndex] || '';
+            } else {
+                historyIndex = commandHistory.length;
                 farshid_input.value = '';
             }
         }

--- a/cli.js
+++ b/cli.js
@@ -1,0 +1,45 @@
+const readline = require('readline');
+readline.emitKeypressEvents(process.stdin);
+if (process.stdin.isTTY) process.stdin.setRawMode(true);
+
+const rl = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout,
+  prompt: 'type your command> '
+});
+
+const history = [];
+let historyIndex = 0;
+
+console.log('Simple CLI. Press up/down to navigate the last 10 commands.');
+rl.prompt();
+
+process.stdin.on('keypress', (str, key) => {
+  if (key.name === 'up') {
+    if (historyIndex > 0) historyIndex--;
+    const cmd = history[historyIndex] || '';
+    rl.write(null, { ctrl: true, name: 'u' });
+    rl.write(cmd);
+  } else if (key.name === 'down') {
+    if (historyIndex < history.length) historyIndex++;
+    const cmd = history[historyIndex] || '';
+    rl.write(null, { ctrl: true, name: 'u' });
+    rl.write(cmd);
+  } else if (key.sequence === '\u0003') {
+    rl.close();
+  }
+});
+
+rl.on('line', line => {
+  const trimmed = line.trim();
+  if (trimmed) {
+    history.push(trimmed);
+    if (history.length > 10) history.shift();
+  }
+  historyIndex = history.length;
+  console.log(`You typed: ${line}`);
+  rl.prompt();
+}).on('close', () => {
+  console.log('Session ended');
+  process.exit(0);
+});

--- a/index.php
+++ b/index.php
@@ -4,7 +4,7 @@
 
 <div class="farshid_terminal_input_row">
     <div class="farshid_terminal_prompt">&gt;</div>
-    <input id="farshid_terminal_input" class="farshid_terminal_input" type="text" placeholder="<?php esc_attr_e('Type your command...', 'terminal'); ?>">
+    <input id="farshid_terminal_input" class="farshid_terminal_input" type="text" placeholder="<?php esc_attr_e('type your command', 'terminal'); ?>">
 </div>
 
 

--- a/languages/terminal-en_US.po
+++ b/languages/terminal-en_US.po
@@ -12,8 +12,8 @@ msgstr "No posts found"
 msgid "Type 'help' for pages or 'posts' to view posts"
 msgstr "Type 'help' for pages or 'posts' to view posts"
 
-msgid "Type your command..."
-msgstr "Type your command..."
+msgid "type your command"
+msgstr "type your command"
 
 msgid "© %1$s %2$s. All rights reserved."
 msgstr "© %1$s %2$s. All rights reserved."

--- a/languages/terminal-fa_IR.po
+++ b/languages/terminal-fa_IR.po
@@ -12,8 +12,8 @@ msgstr "هیچ نوشته‌ای یافت نشد"
 msgid "Type 'help' for pages or 'posts' to view posts"
 msgstr "عبارت 'help' را برای فهرست صفحات یا 'posts' برای دیدن نوشته‌ها وارد کنید"
 
-msgid "Type your command..."
-msgstr "دستور خود را وارد کنید..."
+msgid "type your command"
+msgstr "دستور خود را وارد کنید"
 
 msgid "© %1$s %2$s. All rights reserved."
 msgstr "© %1$s %2$s. تمامی حقوق محفوظ است."


### PR DESCRIPTION
## Summary
- adjust placeholder translations to "type your command"
- store commands in sessionStorage and add up/down navigation
- document browser terminal history in README

## Testing
- `node cli.js </dev/null`
- `php -v >/dev/null 2>&1 && php -l index.php`

------
https://chatgpt.com/codex/tasks/task_e_684ebbd93ec083268f6d89cc04730e45