### PR TITLE
Add robust session history handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,5 +13,6 @@ up to 10 items. Press the **up** arrow to recall earlier commands and the
 
 The WordPress theme includes an input field with the same "type your command"
 placeholder. Up to 10 commands are stored per browser session using
-`sessionStorage`. Use the ArrowUp and ArrowDown keys to cycle through previous
-commands just like a terminal.
+`sessionStorage`. If `sessionStorage` isn't available, history is kept only for
+that page in memory. Use the ArrowUp and ArrowDown keys to cycle through
+previous commands just like a terminal.

--- a/assets/main.js
+++ b/assets/main.js
@@ -18,8 +18,22 @@ document.addEventListener('DOMContentLoaded', function () {
     const farshid_posts_per_page = 10;
 
     // Load command history from this session and track current index
-    let commandHistory = JSON.parse(sessionStorage.getItem('terminalHistory') || '[]');
+    let commandHistory = [];
+    try {
+        commandHistory = JSON.parse(sessionStorage.getItem('terminalHistory')) || [];
+    } catch (err) {
+        // sessionStorage might be unavailable (e.g., private mode)
+        commandHistory = [];
+    }
     let historyIndex = commandHistory.length;
+
+    function saveHistory() {
+        try {
+            sessionStorage.setItem('terminalHistory', JSON.stringify(commandHistory));
+        } catch (err) {
+            // Ignore errors when sessionStorage is not accessible
+        }
+    }
 
     function farshid_addBlock(command, output, isWarning = false) {
         const block = document.createElement('div');
@@ -127,7 +141,7 @@ document.addEventListener('DOMContentLoaded', function () {
                 if (commandHistory.length > 10) {
                     commandHistory.shift();
                 }
-                sessionStorage.setItem('terminalHistory', JSON.stringify(commandHistory));
+                saveHistory();
                 historyIndex = commandHistory.length;
 
                 farshid_input.value = '';


### PR DESCRIPTION
## Summary
- handle `sessionStorage` errors in main.js to keep history in-memory if needed
- document the fallback behavior in README

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684ec0ecbcf483269dd206f2bf4bd4ba